### PR TITLE
chore(deps): upgrade docker actions to the latest available

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
     type: "boolean"
     default: "true"
   BUILD_ARGS:
-    description: All build args 
+    description: All build args
     required: false
   SKIP_CHECKOUT:
     description: "Allows to skip checkout to generate Dockerfile manually"
@@ -52,7 +52,7 @@ runs:
 
   - name: Set up Docker Buildx
     id: buildx
-    uses: docker/setup-buildx-action@v2.5.0
+    uses: docker/setup-buildx-action@v3.0.0
 
   - name: Login to registry
     uses: docker/login-action@v1
@@ -66,7 +66,7 @@ runs:
   # scan
   - name: Build image localy first
     if: inputs.SECURITY_SCAN == 'true'
-    uses: docker/build-push-action@v4.0.0
+    uses: docker/build-push-action@v5.0.0
     id: docker_build
     with:
       context: ${{inputs.BUILD_CONTEXT}}
@@ -100,7 +100,7 @@ runs:
 
   # if SECURITY_SCAN was done, image is already build, else we build it now
   - name: Build image and push to registry
-    uses: docker/build-push-action@v4.0.0
+    uses: docker/build-push-action@v5.0.0
     id: docker_build_push
     with:
       context: ${{inputs.BUILD_CONTEXT}}


### PR DESCRIPTION
Node 20 as default runtime (requires Actions Runner v2.308.0 or later)
Bump @actions/core from 1.10.0 to 1.10.1

cf https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0,
https://github.com/docker/build-push-action/releases/tag/v5.0.0
